### PR TITLE
Add an option to cycle through all configs

### DIFF
--- a/MMM-ImmichSlideShow.js
+++ b/MMM-ImmichSlideShow.js
@@ -6,17 +6,9 @@
  * Module: MMM-ImmichSlideShow
  *
  * Magic Mirror By Michael Teeuw http://michaelteeuw.nl
- * MIT Licens      this.config.immichConfigs.forEach((element,idx) => {
-      // If the entry does not have a dateFormat specified, set it to default
-      if (!element.hasOwnProperty('dateFormat')) {
-        element.dateFormat = DEFAULT_DATE_FORMAT;
-      }
-      // If cyclicConfigs is not defined, set default
-      if (!this.config.hasOwnProperty('cyclicConfigs')) {
-        this.config.cyclicConfigs = this.defaultConfig.cyclicConfigs;
-      }
-      this.config.immichConfigs[idx] = {...this.config.immichConfigs[0],...element};
-      const curConfig = this.config.immichConfigs[idx]; * Module MMM-Slideshow By Darick Carpenter
+ * MIT Licensed.
+ *
+ * Module MMM-Slideshow By Darick Carpenter
  * MIT Licensed.
  */
 // const Log = console;

--- a/MMM-ImmichSlideShow.js
+++ b/MMM-ImmichSlideShow.js
@@ -6,9 +6,17 @@
  * Module: MMM-ImmichSlideShow
  *
  * Magic Mirror By Michael Teeuw http://michaelteeuw.nl
- * MIT Licensed.
- *
- * Module MMM-Slideshow By Darick Carpenter
+ * MIT Licens      this.config.immichConfigs.forEach((element,idx) => {
+      // If the entry does not have a dateFormat specified, set it to default
+      if (!element.hasOwnProperty('dateFormat')) {
+        element.dateFormat = DEFAULT_DATE_FORMAT;
+      }
+      // If cyclicConfigs is not defined, set default
+      if (!this.config.hasOwnProperty('cyclicConfigs')) {
+        this.config.cyclicConfigs = this.defaultConfig.cyclicConfigs;
+      }
+      this.config.immichConfigs[idx] = {...this.config.immichConfigs[0],...element};
+      const curConfig = this.config.immichConfigs[idx]; * Module MMM-Slideshow By Darick Carpenter
  * MIT Licensed.
  */
 // const Log = console;
@@ -53,7 +61,9 @@ Module.register('MMM-ImmichSlideShow', {
     // a comma separated list of values to display: name, date, since, geo
     imageInfo: ['date', 'since', 'count'],
     // the date format to use for imageInfo
-    dateFormat: DEFAULT_DATE_FORMAT
+    dateFormat: DEFAULT_DATE_FORMAT,
+    // whether to cycle through configs after reaching the last image
+    cyclicConfigs: false
   },
 
   // Default module config.
@@ -387,6 +397,11 @@ Module.register('MMM-ImmichSlideShow', {
       } else if (notification === 'IMMICHSLIDESHOW_REGISTER_CONFIG') {
         // Update config in backend
         this.updateImageList();
+      } else if (notification === 'IMMICHSLIDESHOW_CONFIG_CHANGED') {
+        // Config was changed due to cyclic configs
+        Log.debug(LOG_PREFIX + 'Config changed by cycling to index: ' + payload.configIndex);
+        this.config.activeImmichConfigIndex = payload.configIndex;
+        this.config.activeImmichConfig = this.config.immichConfigs[payload.configIndex];
       } else {
         Log.warn(LOG_PREFIX + 'received an unexpected module notification: ' + notification);
       }

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ The following properties can be configured:
 			See <b>Immich Configuration Options</b> below<br/>	
 			</td>
 		</tr>
+		<tr>
+			<td><code>cyclicConfigs</code></td>
+			<td>When set to true, after reaching the last image in a configuration, the module will automatically switch to the next configuration in the <code>immichConfigs</code> array. This allows you to cycle through all your configured albums or modes automatically.<br/>
+			<br/><b>Example:</b> <code>true</code>
+			<br/><b>Default value:</b> <code>false</code>
+			<br/>This value is <b>OPTIONAL</b>
+			</td>
+		</tr>
         <tr>
 			<td><code>activeImmichConfigIndex</code></td>
 			<td>Integer value indicating which of the Immich configurations (immichConfigs) is active.  This can be changed at run time as well and defaults to 0 if not provided.<br>


### PR DESCRIPTION
Added `cyclicConfigs` option (default: false) to automatically rotate through multiple Immich configurations. When enabled, the slideshow will display all images from the current config, then seamlessly switch to the next configuration.

## Use Cases
- Create sequential slideshows from different configs (family photos → vacation → pets)
- I used this to overcome the limitation of 1000 images by adding multiple configs in chronical order