### PR TITLE
Add Anniversary Mode for Date Range Photos Across Years

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,11 +347,12 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>mode</code></td>
-			<td>The mode of operation for the module.  Valid options are 'memory', 'album', 'search'(Experimental), or 'random' and depending on which is chosen, additional settings are required.<br>
+			<td>The mode of operation for the module.  Valid options are 'memory', 'album', 'search'(Experimental), 'random', or 'anniversary' and depending on which is chosen, additional settings are required.<br>
 				<br><b>Example:</b> <code>memory</code> for memory mode
 				<br><b>Example:</b> <code>album</code> for album mode
 				<br><b>Example:</b> <code>search</code> for search mode
 				<br><b>Example:</b> <code>random</code> for random mode
+				<br><b>Example:</b> <code>anniversary</code> for anniversary mode
 				<br>This value is <b>REQUIRED</b>
 			</td>
 		</tr>
@@ -381,20 +382,52 @@ The following properties can be configured:
         <tr>
             <td><code>query</code></td>
             <td>
-                The query object used to search for images in <i>search</i> mode and <i>random</i> mode. This is an advanced feature and the expected value here is meant to be a JSON matching what Immich currently supports.<br>
+                The query object used to search for images in <i>search</i>, <i>random</i>, and <i>anniversary</i> mode. This is an advanced feature and the expected value here is meant to be a JSON matching what Immich currently supports.<br>
                 <br><b>For search mode:</b> The query parameter contains search criteria like text queries, location filters, etc. Refer to: <a target="immich_api" href="https://immich.app/docs/api/search-smart">Immich Smart Search</a> for more detail<br>
-                    <b>Example for search:</b> <code>{ "query": "animals", "city": "Montreal" }</code><br>
+                    <b>Example:</b> <code>{ "query": "animals", "city": "Montreal" }</code><br>
                     <code>query</code> is <b>REQUIRED</b> if <i>mode</i> is set to <i>search</i>.<br>
-                <br><b>For random mode:</b> The query parameter can include filters like albumIds, personIds, favorites, etc. Refer to <a target="immich_api" href="https://immich.app/docs/api/search-random">Immich Random Search</a> for more detail.<br>
-                    <b>Example for random:</b> <code>{ "isFavorite": true, "withPeople": true }</code><br>
+                <br><b>For random and anniversary mode:</b> The query parameter can include filters like albumIds, personIds, favorites, etc. Refer to <a target="immich_api" href="https://immich.app/docs/api/search-random">Immich Random Search</a> for more detail.<br>
+                    <b>Example:</b> <code>{ "isFavorite": true, "withPeople": true }</code><br>
             </td>
         </tr>
 		<tr>
 			<td><code>querySize</code></td>
-			<td>The number of images to return when in <i>search</i> or <i>random</i> mode.  Although, this can also be specified as a <i>size</i> parameter in <i>query</i>, the value specified here overwrites that value.  This value must be between 1 and 1000.<br>
+			<td>The number of images to return when in <i>search</i>, <i>random</i>, or <i>anniversary</i> mode.  Although, this can also be specified as a <i>size</i> parameter in <i>query</i>, the value specified here overwrites that value.  This value must be between 1 and 1000.<br>
 				<br><b>Example:</b> <code>150</code>
 				<br><b>Default value:</b> <code>100</code>
-				<br>This value is <b>REQUIRED</b> if <i>mode</i> is set to <i>search</i> or <i>random</i>.
+				<br>This value is <b>REQUIRED</b> if <i>mode</i> is set to <i>search</i>, <i>random</i>, or <i>anniversary</i>.
+			</td>
+		</tr>
+		<tr>
+			<td><code>anniversaryDatesBack</code></td>
+			<td>The number of days to look back from today's date when in <i>anniversary</i> mode. For example, if today is July 30th and this is set to 3, it will look for images from July 27th onwards for each year in the range.<br>
+				<br><b>Example:</b> <code>3</code>
+				<br><b>Default value:</b> <code>3</code>
+				<br>This value is <b>REQUIRED</b> if <i>mode</i> is set to <i>anniversary</i>.
+			</td>
+		</tr>
+		<tr>
+			<td><code>anniversaryDatesForward</code></td>
+			<td>The number of days to look forward from today's date when in <i>anniversary</i> mode. For example, if today is July 30th and this is set to 3, it will look for images up to August 2nd for each year in the range.<br>
+				<br><b>Example:</b> <code>3</code>
+				<br><b>Default value:</b> <code>3</code>
+				<br>This value is <b>REQUIRED</b> if <i>mode</i> is set to <i>anniversary</i>.
+			</td>
+		</tr>
+		<tr>
+			<td><code>anniversaryStartYear</code></td>
+			<td>The starting year for the anniversary search. The module will search for images in the date range for each year from this year to <i>anniversaryEndYear</i>.<br>
+				<br><b>Example:</b> <code>2020</code>
+				<br><b>Default value:</b> <code>2020</code>
+				<br>This value is <b>REQUIRED</b> if <i>mode</i> is set to <i>anniversary</i>.
+			</td>
+		</tr>
+		<tr>
+			<td><code>anniversaryEndYear</code></td>
+			<td>The ending year for the anniversary search. The module will search for images in the date range for each year from <i>anniversaryStartYear</i> to this year.<br>
+				<br><b>Example:</b> <code>2025</code>
+				<br><b>Default value:</b> <code>2025</code>
+				<br>This value is <b>REQUIRED</b> if <i>mode</i> is set to <i>anniversary</i>.
 			</td>
 		</tr>
 		<tr>
@@ -434,7 +467,6 @@ The following properties can be configured:
 	</tbody>
 </table>
 
-
 ### Configuration Example
 ```javascript
 ...
@@ -466,6 +498,21 @@ modules: [
             },
             imageInfo: ['date','since','people'],
             slideshowSpeed: 10000
+          },
+          {
+            // The module will search for 100 photos taken between July 27th - August 2nd for each year from 2020 to 2025, creating 6 separate queries and combining all results.
+            mode: 'anniversary',
+            anniversaryDatesBack: 5,
+            anniversaryDatesForward: 2,
+            anniversaryStartYear: 2018,
+            anniversaryEndYear: 2025,
+            querySize: 50,
+            query: {
+              isFavorite: true,
+              withPeople: true
+            },
+            imageInfo: ['date','since','people'],
+            slideshowSpeed: 20000
           }
         ],
         activeImmichConfigIndex: 0,

--- a/immichApi.js
+++ b/immichApi.js
@@ -1,4 +1,3 @@
-
 // const Log = console;
 const Log = require('logger');
 const axios = require('axios');
@@ -308,10 +307,9 @@ const immichApi = {
     anniversarySearchAssets: async function (datesBack, datesForward, startYear, endYear, querySize, query) {
         let imageList = [];
         
-        Log.debug(LOG_PREFIX + 'Searching for anniversary images:', { datesBack, datesForward, startYear, endYear, querySize, query });
+        Log.warn(LOG_PREFIX + 'Searching for anniversary images:', { datesBack, datesForward, startYear, endYear, querySize, query });
         
         const today = new Date();
-        const currentMonth = today.getMonth() + 1; // getMonth() returns 0-11
         const currentDay = today.getDate();
         
         try {
@@ -321,28 +319,33 @@ const immichApi = {
             const endDate = new Date(today);
             endDate.setDate(currentDay + datesForward);
             
-            const startMonth = startDate.getMonth() + 1;
+            // Get month and day values directly
+            const startMonth = startDate.getMonth();
             const startDay = startDate.getDate();
-            const endMonth = endDate.getMonth() + 1;
+            const endMonth = endDate.getMonth();
             const endDay = endDate.getDate();
             
-            Log.debug(LOG_PREFIX + 'Anniversary date range: ', 
-                `${startMonth.toString().padStart(2, '0')}-${startDay.toString().padStart(2, '0')} to ${endMonth.toString().padStart(2, '0')}-${endDay.toString().padStart(2, '0')}`);
+            Log.warn(LOG_PREFIX + 'Anniversary date range: ', 
+                `${(startMonth+1).toString().padStart(2, '0')}-${startDay.toString().padStart(2, '0')} to ${(endMonth+1).toString().padStart(2, '0')}-${endDay.toString().padStart(2, '0')}`);
             
             // For each year in the range, search for images
             for (let year = startYear; year <= endYear; year++) {
-                const yearStartDate = new Date(year, startMonth - 1, startDay);
-                const yearEndDate = new Date(year, endMonth - 1, endDay);
+                // Handle year boundary crossing properly
+                let searchStartYear = year;
+                let searchEndYear = year;
                 
-                // Handle cross-month scenarios (e.g., July 29 - August 2)
-                if (endDate.getDate() < startDate.getDate()) {
-                    yearEndDate.setMonth(yearEndDate.getMonth() + 1);
+                // If date range wraps from end to beginning of year
+                if (startMonth > endMonth || (startMonth === endMonth && startDay > endDay)) {
+                    searchEndYear = year + 1;
                 }
+                
+                const yearStartDate = new Date(searchStartYear, startMonth, startDay);
+                const yearEndDate = new Date(searchEndYear, endMonth, endDay);
                 
                 const startDateString = yearStartDate.toISOString().split('T')[0];
                 const endDateString = yearEndDate.toISOString().split('T')[0];
                 
-                Log.debug(LOG_PREFIX + `Searching for year ${year}: ${startDateString} to ${endDateString}`);
+                Log.warn(LOG_PREFIX + `Searching for year ${year}: ${startDateString} to ${endDateString}`);
                 
                 const searchQuery = {};
                 
@@ -362,7 +365,7 @@ const immichApi = {
                     
                     if (response.status === 200) {
                         const yearImages = response.data || [];
-                        Log.debug(LOG_PREFIX + `Found ${yearImages.length} images for year ${year}`);
+                        Log.warn(LOG_PREFIX + `Found ${yearImages.length} images for year ${year}`);
                         imageList = imageList.concat(yearImages);
                     } else {
                         Log.warn(LOG_PREFIX + `Unexpected response from Immich while searching anniversary assets for year ${year}`, response.status, response.statusText);
@@ -376,7 +379,7 @@ const immichApi = {
             Log.error(LOG_PREFIX + 'Oops! Exception while fetching anniversary images from Immich:', e.message);
         }
         
-        Log.debug(LOG_PREFIX + `Total anniversary images found: ${imageList.length}`);
+        Log.warn(LOG_PREFIX + `Total anniversary images found: ${imageList.length}`);
         return imageList;
     },
 

--- a/immichApi.js
+++ b/immichApi.js
@@ -307,7 +307,7 @@ const immichApi = {
     anniversarySearchAssets: async function (datesBack, datesForward, startYear, endYear, querySize, query) {
         let imageList = [];
         
-        Log.warn(LOG_PREFIX + 'Searching for anniversary images:', { datesBack, datesForward, startYear, endYear, querySize, query });
+        Log.debug(LOG_PREFIX + 'Searching for anniversary images:', { datesBack, datesForward, startYear, endYear, querySize, query });
         
         const today = new Date();
         const currentDay = today.getDate();
@@ -325,7 +325,7 @@ const immichApi = {
             const endMonth = endDate.getMonth();
             const endDay = endDate.getDate();
             
-            Log.warn(LOG_PREFIX + 'Anniversary date range: ', 
+            Log.debug(LOG_PREFIX + 'Anniversary date range: ', 
                 `${(startMonth+1).toString().padStart(2, '0')}-${startDay.toString().padStart(2, '0')} to ${(endMonth+1).toString().padStart(2, '0')}-${endDay.toString().padStart(2, '0')}`);
             
             // For each year in the range, search for images
@@ -345,7 +345,7 @@ const immichApi = {
                 const startDateString = yearStartDate.toISOString().split('T')[0];
                 const endDateString = yearEndDate.toISOString().split('T')[0];
                 
-                Log.warn(LOG_PREFIX + `Searching for year ${year}: ${startDateString} to ${endDateString}`);
+                Log.debug(LOG_PREFIX + `Searching for year ${year}: ${startDateString} to ${endDateString}`);
                 
                 const searchQuery = {};
                 
@@ -365,10 +365,10 @@ const immichApi = {
                     
                     if (response.status === 200) {
                         const yearImages = response.data || [];
-                        Log.warn(LOG_PREFIX + `Found ${yearImages.length} images for year ${year}`);
+                        Log.debug(LOG_PREFIX + `Found ${yearImages.length} images for year ${year}`);
                         imageList = imageList.concat(yearImages);
                     } else {
-                        Log.warn(LOG_PREFIX + `Unexpected response from Immich while searching anniversary assets for year ${year}`, response.status, response.statusText);
+                        Log.debug(LOG_PREFIX + `Unexpected response from Immich while searching anniversary assets for year ${year}`, response.status, response.statusText);
                     }
                 } catch (yearError) {
                     Log.warn(LOG_PREFIX + `Exception while fetching anniversary images for year ${year}:`, yearError.message);
@@ -379,7 +379,7 @@ const immichApi = {
             Log.error(LOG_PREFIX + 'Oops! Exception while fetching anniversary images from Immich:', e.message);
         }
         
-        Log.warn(LOG_PREFIX + `Total anniversary images found: ${imageList.length}`);
+        Log.debug(LOG_PREFIX + `Total anniversary images found: ${imageList.length}`);
         return imageList;
     },
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -176,6 +176,16 @@ module.exports = NodeHelper.create({
         config.activeImmichConfig.querySize || 100, 
         config.activeImmichConfig.query || null
       );
+    } else if (config.activeImmichConfig.mode === 'anniversary') {
+      // Anniversary mode
+      this.imageList = await immichApi.anniversarySearchAssets(
+        config.activeImmichConfig.anniversaryDatesBack || 3,
+        config.activeImmichConfig.anniversaryDatesForward || 3,
+        config.activeImmichConfig.anniversaryStartYear || 2020,
+        config.activeImmichConfig.anniversaryEndYear || 2025,
+        config.activeImmichConfig.querySize || 100,
+        config.activeImmichConfig.query || null
+      );
     } else {
       // Assume we are in memory mode
       this.imageList = await immichApi.getMemoryLaneAssets(config.activeImmichConfig.numDaysToInclude);


### PR DESCRIPTION
This PR adds a new 'anniversary' mode that displays photos taken on or near the current date across multiple years. Users can specify:

- How many days to look back before the current date
- How many days to look forward after the current date
- A starting year and ending year for the range
- query: number of image for each year
- For example, if today is July 30th with a 3-day range in both directions, the module will search for photos taken between July 27th and August 2nd for each year from the starting year to ending year.