### PR TITLE
Include EXIF data (f-stop, exposure time, focal length equivalent, ISO) in imageInfo output 

### DIFF
--- a/MMM-ImmichSlideShow.js
+++ b/MMM-ImmichSlideShow.js
@@ -602,14 +602,14 @@ Module.register('MMM-ImmichSlideShow', {
     }
   },
 
-  // FUNZIONE MODIFICATA: Aggiunti helper per formattare i dati EXIF
+  /// Function to format EXIF data
   formatExposureTime: function(exposureTime) {
     if (!exposureTime) return null;
 
     let numericValue;
 
     if (typeof exposureTime === 'string') {
-      // Gestisce il caso "1/xxx"
+      // Case "1/xxx"
       if (exposureTime.includes('/')) {
         const parts = exposureTime.replace('s', '').split('/');
         if (parts.length === 2) {
@@ -618,7 +618,7 @@ Module.register('MMM-ImmichSlideShow', {
           if (numerator === 1 && !isNaN(denominator) && denominator !== 0) {
             numericValue = 1 / denominator;
           } else {
-            return null; // Formato non valido
+            return null; // Invalid format
           }
         } else {
           return null;
@@ -638,15 +638,15 @@ Module.register('MMM-ImmichSlideShow', {
       const denominator = Math.round(1 / numericValue);
 
       if (denominator <= 125) {
-        // Da 1/125s a 1s → arrotonda ai 5 più vicini
+        // From 1/125s to 1s → round 5
         const rounded = Math.round(denominator / 5) * 5;
         return `1/${rounded}s`;
       } else if (denominator <= 500) {
-        // Tempi veloci fino a 1/500s → arrotonda ai 50
+        // Up to 1/500s → round 50
         const rounded = Math.round(denominator / 50) * 50;
         return `1/${rounded}s`;
       } else {
-        // Tempi ancora più veloci → arrotonda ai 100
+        // Faster times → round 100
         const rounded = Math.round(denominator / 100) * 100;
         return `1/${rounded}s`;
       }
@@ -710,20 +710,20 @@ Module.register('MMM-ImmichSlideShow', {
             imageProps.push(geoLocation);
           }
           break;
-        // NUOVO CASO: Mostra dati EXIF tecnici
+        // Show EXIF data
         case 'exif': // show EXIF technical data
           if (imageinfo.exifInfo) {
             let exifData = [];
             
-            // Apertura (f-stop)
+            // Aperture (f-stop)
             const aperture = this.formatAperture(imageinfo.exifInfo.fNumber);
             if (aperture) exifData.push(aperture);
             
-            // Tempo di esposizione
+            // Exposition time
             const exposureTime = this.formatExposureTime(imageinfo.exifInfo.exposureTime);
             if (exposureTime) exifData.push(exposureTime);
             
-            // Lunghezza focale
+            // Focal lenght
             const focalLength = this.formatFocalLength(imageinfo.exifInfo.focalLength);
             if (focalLength) exifData.push(focalLength);
             

--- a/MMM-ImmichSlideShow.js
+++ b/MMM-ImmichSlideShow.js
@@ -604,54 +604,54 @@ Module.register('MMM-ImmichSlideShow', {
 
   // FUNZIONE MODIFICATA: Aggiunti helper per formattare i dati EXIF
   formatExposureTime: function(exposureTime) {
-  if (!exposureTime) return null;
+    if (!exposureTime) return null;
 
-  let numericValue;
+    let numericValue;
 
-  if (typeof exposureTime === 'string') {
-    // Gestisce il caso "1/xxx"
-    if (exposureTime.includes('/')) {
-      const parts = exposureTime.replace('s', '').split('/');
-      if (parts.length === 2) {
-        const numerator = parseFloat(parts[0]);
-        const denominator = parseFloat(parts[1]);
-        if (numerator === 1 && !isNaN(denominator) && denominator !== 0) {
-          numericValue = 1 / denominator;
+    if (typeof exposureTime === 'string') {
+      // Gestisce il caso "1/xxx"
+      if (exposureTime.includes('/')) {
+        const parts = exposureTime.replace('s', '').split('/');
+        if (parts.length === 2) {
+          const numerator = parseFloat(parts[0]);
+          const denominator = parseFloat(parts[1]);
+          if (numerator === 1 && !isNaN(denominator) && denominator !== 0) {
+            numericValue = 1 / denominator;
+          } else {
+            return null; // Formato non valido
+          }
         } else {
-          return null; // Formato non valido
+          return null;
         }
       } else {
-        return null;
+        numericValue = parseFloat(exposureTime);
       }
     } else {
       numericValue = parseFloat(exposureTime);
     }
-  } else {
-    numericValue = parseFloat(exposureTime);
-  }
 
-  if (isNaN(numericValue)) return null;
+    if (isNaN(numericValue)) return null;
 
-  if (numericValue >= 1) {
-    return numericValue % 1 === 0 ? `${numericValue}s` : `${numericValue.toFixed(1)}s`;
-  } else {
-    const denominator = Math.round(1 / numericValue);
-
-    if (denominator <= 125) {
-      // Da 1/125s a 1s → arrotonda ai 5 più vicini
-      const rounded = Math.round(denominator / 5) * 5;
-      return `1/${rounded}s`;
-    } else if (denominator <= 500) {
-      // Tempi veloci fino a 1/500s → arrotonda ai 50
-      const rounded = Math.round(denominator / 50) * 50;
-      return `1/${rounded}s`;
+    if (numericValue >= 1) {
+      return numericValue % 1 === 0 ? `${numericValue}s` : `${numericValue.toFixed(1)}s`;
     } else {
-      // Tempi ancora più veloci → arrotonda ai 100
-      const rounded = Math.round(denominator / 100) * 100;
-      return `1/${rounded}s`;
+      const denominator = Math.round(1 / numericValue);
+
+      if (denominator <= 125) {
+        // Da 1/125s a 1s → arrotonda ai 5 più vicini
+        const rounded = Math.round(denominator / 5) * 5;
+        return `1/${rounded}s`;
+      } else if (denominator <= 500) {
+        // Tempi veloci fino a 1/500s → arrotonda ai 50
+        const rounded = Math.round(denominator / 50) * 50;
+        return `1/${rounded}s`;
+      } else {
+        // Tempi ancora più veloci → arrotonda ai 100
+        const rounded = Math.round(denominator / 100) * 100;
+        return `1/${rounded}s`;
+      }
     }
-  }
-},
+  },
 
   formatFocalLength: function(focalLength) {
     if (!focalLength) return null;


### PR DESCRIPTION
The function extracts key EXIF metadata from the image — specifically aperture (f), exposure time, focal length (35mm equivalent), and ISO — and displays them in a compact, single-line format using visual spacers. This keeps the layout clean and avoids clutter while still showing the most relevant photographic settings.

If you think it fits the project, feel free to include or adapt the code I’ve provided.

<img width="289" height="131" alt="Screenshot 2025-08-01 165942" src="https://github.com/user-attachments/assets/3e095196-343c-488f-b951-69124f46ea2b" />
<img width="414" height="182" alt="Screenshot 2025-08-01 170014" src="https://github.com/user-attachments/assets/ff6f1011-76a8-4744-9cf7-3d408b883090" />
